### PR TITLE
environment: remove conda-forge channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: parallel
 channels:
-  - conda-forge
   - defaults
 dependencies:
   - python =3.5


### PR DESCRIPTION
Temporarily fixes https://github.com/pydata/parallel-tutorial/issues/20 while we sort out issues with the conda-forge channel.