### PR TITLE
Add draft of nyc-taxi futures notebook

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,5 @@ dependencies:
   - scikit-learn
   - snakeviz
   - ujson
+  - gcsfs
+  - ipywidgets

--- a/notebooks/07-distributed-cross-validated-parameter-search.ipynb
+++ b/notebooks/07-distributed-cross-validated-parameter-search.ipynb
@@ -75,8 +75,7 @@
     "    'C': np.logspace(-10, 10, 1001),\n",
     "    'gamma': np.logspace(-10, 10, 1001),\n",
     "    'tol': np.logspace(-4, -1, 4),\n",
-    "}\n",
-    "\n"
+    "}"
    ]
   },
   {
@@ -96,9 +95,8 @@
    },
    "outputs": [],
    "source": [
-    "# Split data for cross-validation\n",
-    "cv_splits = [load_cv_split(i) for i in range(2)]\n",
-    "idx, (x_train, x_test, y_train, y_test) = cv_splits[0]"
+    "cv_splits = [load_cv_split(i) for i in range(2)]  # Increase the number 2 after parallel computation acheived\n",
+    "param_samples = ParameterSampler(param_grid, 10)    # Increase the number 10 after parallel computation acheived"
    ]
   },
   {
@@ -157,22 +155,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load solutions/cvgs-2.py\n",
+    "from pyspark import SparkContext\n",
+    "sc = SparkContext(...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "# %load solutions/cvgs-2.py\n",
-    "from pyspark import SparkContext\n",
-    "sc = SparkContext('local[4]')\n",
-    "\n",
     "cv_rdd = sc.parallelize(cv_splits)\n",
     "param_rdd = sc.parallelize(list(param_samples))\n",
     "\n",
     "rdd = param_rdd.cartesian(cv_rdd)\n",
     "results = rdd.map(lambda tup: evaluate_one(SVC, tup[0], tup[1]))\n",
     "\n",
-    "results = results.collect()\n"
+    "results = results.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you need to terminate your spark context\n",
+    "# sc.stop()"
    ]
   },
   {
@@ -213,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/nyc-taxi-dask-dataframes.ipynb
+++ b/notebooks/nyc-taxi-dask-dataframes.ipynb
@@ -1,0 +1,169 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DataFrames (dask)\n",
+    "\n",
+    "In the previous notebook we manipulated and queried a large parquet file by splitting it up into many Pandas dataframes with the concurrent.futures API.  This was straightforward, but required us to be clever to implement various parallel algorithms.  Fortunately, for certain classes of algorithms various big data projects have already done this work for us.  Dealing with tabular data like the data in our NYC-Taxi dataset is well covered by many systems like SQL databases, Spark, and Dask.dataframes.\n",
+    "\n",
+    "At the end of the last notebook we saw that we could use Pandas-like syntax to accomplish the same result with less programming."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gcsfs import GCSFileSystem\n",
+    "gcs = GCSFileSystem(token='cloud')\n",
+    "\n",
+    "from dask.distributed import Client, progress\n",
+    "client = Client('schedulers:9000')\n",
+    "client.restart()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "df = dd.read_parquet('gcs://anaconda-public-data/nyc-taxi/2015.parquet').persist()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.passenger_count.sum().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.passenger_count.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.passenger_count.value_counts().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Going further\n",
+    "\n",
+    "In this notebook we will explore this API and this dataset further.  We will determine how well people tip based on the number of passengers in a cab.  To do this we will accomplish the following:\n",
+    "\n",
+    "1.  Remove rides with zero fare\n",
+    "2.  Add a new column `tip_fraction` that is equal to the ratio of the tip to the fare\n",
+    "3.  Group by the `passenger_count` column and take the mean of the `tip_fraction` column."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to remove rows\n",
+    "\n",
+    "In Pandas you can filter rows by a boolean expression like the following:\n",
+    "\n",
+    "```python\n",
+    "df = df[df.name == 'Alice']\n",
+    "```\n",
+    "\n",
+    "### How to make new columns\n",
+    "\n",
+    "In Pandas you can create a new column using Python's setitem syntax like the following:\n",
+    "\n",
+    "```python\n",
+    "df['z'] = df.x + df.y\n",
+    "```\n",
+    "\n",
+    "### How to do groupby-aggregations\n",
+    "\n",
+    "In Pandas you can do a groupby-aggregation by using the `groupby` method, followed by a column name an aggregation method like the following:\n",
+    "\n",
+    "```python\n",
+    "df.groupby(df.name).value.mean()\n",
+    "```\n",
+    "\n",
+    "### Dask.dataframes\n",
+    "\n",
+    "In dask.dataframes all of these same commands still work.  The only difference is that at the end of your final line you will need to call `.compute()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "Use the operations above to find out how well New Yorkers tip based on the number of passengers in the cab.  Be sure to filter out rides with zero fare first to get a good result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional exercises\n",
+    "\n",
+    "If you're already experienced with Pandas then we recommend also looking at the following questions:\n",
+    "\n",
+    "1. How well do New Yorkers tip as a function of the hour of day and the day of the week?\n",
+    "2.  Investiate the `payment_type` column.  See how well each of the payment types correlate with the `tip_fraction`.  Did you find anything interesting?  Any guesses on what the different payment types might be?  If you're interested you may be able to find more information on the [NYC TLC's website](http://www.nyc.gov/html/tlc/html/about/trip_record_data.shtml)\n",
+    "3.  How quickly can you get the data for a particular day of the year?  How about for a particular hour of that day?\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/nyc-taxi-futures.ipynb
+++ b/notebooks/nyc-taxi-futures.ipynb
@@ -1,0 +1,335 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# From concurrent.futures to Dataframes\n",
+    "\n",
+    "In this notebook we look at real data while using a cluster of computers.  For programming we will start with concurrent.futures and then transition to parallel dataframes.  This will give us experience with real data and provide some intuition about what is happening when we use big dataframes such as are provided by Spark or Dask dataframe.\n",
+    "\n",
+    "To begin, we look at the New York City taxi cab dataset.  This includes every ride made in the city of New York in the year 2016.  This data is stored in the Parquet format, which we can read with the [fastparquet](http://fastparquet.readthedocs.io/en/latest/) Python library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Parquet File: {'name': '/home/mrocklin/data/nyc/nyc-2016.parquet//_metadata', 'columns': ['tpep_pickup_datetime', 'VendorID', 'tpep_dropoff_datetime', 'passenger_count', 'trip_distance', 'pickup_longitude', 'pickup_latitude', 'RateCodeID', 'store_and_fwd_flag', 'dropoff_longitude', 'dropoff_latitude', 'payment_type', 'fare_amount', 'extra', 'mta_tax', 'tip_amount', 'tolls_amount', 'improvement_surcharge', 'total_amount'], 'partitions': [], 'rows': 146112989}>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import fastparquet\n",
+    "\n",
+    "pf = fastparquet.ParquetFile('/home/mrocklin/data/nyc/nyc-2016.parquet/')\n",
+    "pf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading a subset \n",
+    "\n",
+    "Normally we would call the `pf.to_pandas()` method to read this data into memory as a Pandas dataframe.  In this case however that would be unwise because this data is too large to fit comfortably in RAM (please do not try this).\n",
+    "\n",
+    "Fortunately Parquet files are split into row groups, each of which does fit nicely into memory.  The following function will read a single row group for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastparquet.api import _pre_allocate\n",
+    "from fastparquet.core import read_row_group_file\n",
+    "\n",
+    "def read_row_group(rg):\n",
+    "    fn = pf.row_group_filename(rg)\n",
+    "    columns = pf.columns\n",
+    "    categories = {}\n",
+    "    index = None\n",
+    "    cs = {}\n",
+    "    dt = pf.dtypes\n",
+    "    schema = pf.schema\n",
+    "\n",
+    "\n",
+    "    df, views = _pre_allocate(rg.num_rows, columns, categories, index, cs, dt)\n",
+    "    read_row_group_file(fn,rg, columns, categories, schema, cs,\n",
+    "                        open=open, assign=views)\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "read_row_group(pf.row_groups[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result of this function call is one Pandas dataframe with a couple million rows.  There are about fifty such groups."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(pf.row_groups)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remote execution with concurrent.futures\n",
+    "\n",
+    "While we don't have enough memory to handle all of this data locally, we can ask the machines in our cluster to do this work for us.  We connect to the cluster with Dask below and use the concurrent.futures interface to load call this same function remotely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client, progress\n",
+    "client = Client()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "future = client.submit(read_row_group, rg)\n",
+    "future"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you watch [Dask's diagnostic dashboard](../../../9002/status) you will see this function run and stay in memory on one of the remote workers.\n",
+    "\n",
+    "The Pandas dataframe now lives on that machine.  We can submit computations to run on that remote dataframe by submitting new tasks onto our future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len_future = client.submit(len, future)\n",
+    "len_future"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This too runs remotely.  By calling submit on futures we can chain computations without ever bringing the data back to our local machine.\n",
+    "\n",
+    "However, if we do want to bring data back, we can do so with the `.result()` method like before.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len_future.result()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With a `ThreadPoolExecutor` calling `.result()` did two things\n",
+    "\n",
+    "1.  Wait for the computation to finish\n",
+    "2.  Return the finished value\n",
+    "\n",
+    "Now calling result does *three* things\n",
+    "\n",
+    "1.  Wait for the computation to finish\n",
+    "2.  **Communicate** the data from the worker to our local machine\n",
+    "3.  Return the finished value\n",
+    "\n",
+    "This extra step of communication can be *expensive* so we prefer not to call result unless we really have to.  For example, it might take a while if we gather the full dataframe back from the worker to our local machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time local_df = future.result()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extra cost of communication is something that we should be aware of."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Now that we have some real data, lets compute some things about New York.\n",
+    "\n",
+    "1.  How many passengers rode in cab rides in 2016 total?\n",
+    "2.  How many rides had more than two passengers?\n",
+    "3.  What was the average number of passengers over all rides?\n",
+    "4.  (hard) How many rides were there holding one passenger, two passengers, three passengers, etc..\n",
+    "\n",
+    "First, use `client.submit` or `client.map` and the `read_row_group` function on each of the row groups to create a list of futures of Pandas dataframes in remote memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use map or submit with the `read_row_group` function \n",
+    "# on each of the row groups to get a list of futures of Pandas dataframes\n",
+    "\n",
+    "futures = ...\n",
+    "\n",
+    "# How much memory do these take up across the cluster\n",
+    "# (this is on the diagnostic dashboard)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How many passengers rode in cab rides in 2016 total?\n",
+    "# (answer provided for this question)\n",
+    "\n",
+    "def f(df):\n",
+    "    return df.passenger_count.sum()\n",
+    "\n",
+    "counts = client.map(f, futures)\n",
+    "total = client.submit(sum, counts)\n",
+    "total.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What was the average number of passengers over all rides?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How many rides were there for each passenger count?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Up Next\n",
+    "\n",
+    "The exercises that we have just done are exactly how projects like Spark Dataframes and Dask dataframes work and the algorithms that we've built are very similar to the algorithms contained within those projects.  However, because all of these tricks have already been implemented we can use them to accomplish the same results, but in much less code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dd.read_parquet(...).persist()\n",
+    "progress(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.passenger_count.sum().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.passenger_count.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.passenger_count.value_counts().compute()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/nyc-taxi-futures.ipynb
+++ b/notebooks/nyc-taxi-futures.ipynb
@@ -8,29 +8,29 @@
     "\n",
     "In this notebook we look at real data while using a cluster of computers.  For programming we will start with concurrent.futures and then transition to parallel dataframes.  This will give us experience with real data and provide some intuition about what is happening when we use big dataframes such as are provided by Spark or Dask dataframe.\n",
     "\n",
-    "To begin, we look at the New York City taxi cab dataset.  This includes every ride made in the city of New York in the year 2016.  This data is stored in the Parquet format, which we can read with the [fastparquet](http://fastparquet.readthedocs.io/en/latest/) Python library."
+    "To begin, we look at the [New York City Taxi Cab dataset](http://www.nyc.gov/html/tlc/html/about/trip_record_data.shtml).  This includes every ride made in the city of New York in the year 2016.  This data is stored in the Parquet format, which we can read with the [fastparquet](http://fastparquet.readthedocs.io/en/latest/) and [gcsfs](http://gcsfs.readthedocs.io/en/latest/) Python libraries."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Parquet File: {'name': '/home/mrocklin/data/nyc/nyc-2016.parquet//_metadata', 'columns': ['tpep_pickup_datetime', 'VendorID', 'tpep_dropoff_datetime', 'passenger_count', 'trip_distance', 'pickup_longitude', 'pickup_latitude', 'RateCodeID', 'store_and_fwd_flag', 'dropoff_longitude', 'dropoff_latitude', 'payment_type', 'fare_amount', 'extra', 'mta_tax', 'tip_amount', 'tolls_amount', 'improvement_surcharge', 'total_amount'], 'partitions': [], 'rows': 146112989}>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "from gcsfs import GCSFileSystem\n",
+    "gcs = GCSFileSystem(token='cloud')\n",
+    "gcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import fastparquet\n",
     "\n",
-    "pf = fastparquet.ParquetFile('/home/mrocklin/data/nyc/nyc-2016.parquet/')\n",
+    "pf = fastparquet.ParquetFile('anaconda-public-data/nyc-taxi/2015.parquet', open_with=gcs.open)\n",
     "pf"
    ]
   },
@@ -40,9 +40,9 @@
    "source": [
     "## Reading a subset \n",
     "\n",
-    "Normally we would call the `pf.to_pandas()` method to read this data into memory as a Pandas dataframe.  In this case however that would be unwise because this data is too large to fit comfortably in RAM (please do not try this).\n",
+    "Normally we would call the `pf.to_pandas()` method to read this data into memory as a Pandas dataframe.  However in this case that would be unwise because this data is too large to fit comfortably in RAM (please do not try this, you will likely kill your notebook session).\n",
     "\n",
-    "Fortunately Parquet files are split into row groups, each of which does fit nicely into memory.  The following function will read a single row group for us."
+    "Fortunately Parquet files are split into row groups, each of which does fit nicely into memory.  The following function will read a single row group for us from our Parquet file."
    ]
   },
   {
@@ -54,6 +54,7 @@
     "from fastparquet.api import _pre_allocate\n",
     "from fastparquet.core import read_row_group_file\n",
     "\n",
+    "\n",
     "def read_row_group(rg):\n",
     "    fn = pf.row_group_filename(rg)\n",
     "    columns = pf.columns\n",
@@ -63,10 +64,9 @@
     "    dt = pf.dtypes\n",
     "    schema = pf.schema\n",
     "\n",
-    "\n",
     "    df, views = _pre_allocate(rg.num_rows, columns, categories, index, cs, dt)\n",
     "    read_row_group_file(fn,rg, columns, categories, schema, cs,\n",
-    "                        open=open, assign=views)\n",
+    "                        open=gcs.open, assign=views)\n",
     "\n",
     "    return df"
    ]
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result of this function call is one Pandas dataframe with a couple million rows.  There are about fifty such groups."
+    "The result of this function call is one Pandas dataframe with a few million rows.  There are several such row groups."
    ]
   },
   {
@@ -112,7 +112,7 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
-    "client = Client()\n",
+    "client = Client('schedulers:9000')\n",
     "client"
    ]
   },
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "future = client.submit(read_row_group, rg)\n",
+    "future = client.submit(read_row_group, pf.row_groups[0])\n",
     "future"
    ]
   },
@@ -279,7 +279,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = dd.read_parquet(...).persist()\n",
+    "import dask.dataframe as dd\n",
+    "df = dd.read_parquet('gcs://anaconda-public-data/nyc-taxi/2015.parquet').persist()\n",
     "progress(df)"
    ]
   },
@@ -327,7 +328,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This adds a notebook that transitions readers from concurrent.futures to dataframes while they first interact with distributed data.

This needs to be modified to use parquet data on gcs